### PR TITLE
Update linux distro url

### DIFF
--- a/docs/manual/source/install/install-linux.html.md.erb
+++ b/docs/manual/source/install/install-linux.html.md.erb
@@ -63,7 +63,7 @@ Download Apache PredictionIO (incubating) and extract it.
 $ cd
 $ pwd
 /home/abc
-$ wget http://download.prediction.io/PredictionIO-<%= data.versions.pio %>.tar.gz
+$ wget https://www.apache.org/dist/incubator/predictionio/<%= data.versions.pio %>-incubating/apache-predictionio-<%= data.versions.pio %>-incubating.tar.gz
 $ tar zxvf PredictionIO-<%= data.versions.pio %>.tar.gz
 ```
 


### PR DESCRIPTION
The distro url appears to be moved to apache.org. Updating linux manual installation page.