### PR TITLE
[PIO-137] Create a connection object at a worker to delete events

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1359,9 +1359,9 @@ Binary distribution bundles
 --------------------------------------------------------------------------------
 Binary distribution bundles
 
+  org.slf4j # slf4j-api # 1.7.25 (https://www.slf4j.org/)
   org.slf4j # slf4j-api # 1.7.18 (https://www.slf4j.org/)
   org.slf4j # slf4j-api # 1.7.16 (https://www.slf4j.org/)
-  org.slf4j # slf4j-api # 1.7.14 (https://www.slf4j.org/)
   org.slf4j # slf4j-api # 1.7.10 (https://www.slf4j.org/)
   org.slf4j # slf4j-api # 1.7.2 (https://www.slf4j.org/)
   org.slf4j # slf4j-log4j12 # 1.7.18 (https://www.slf4j.org/)
@@ -1709,6 +1709,7 @@ Binary distribution bundles
   org.scala-lang # scalap # 2.11.8 (http://scala-lang.org/)
   org.scala-lang.modules # scala-java8-compat_2.11 # 0.7.0 (http://scala-lang.org/)
   org.scala-lang.modules # scala-parser-combinators_2.11 # 1.0.4 (http://scala-lang.org/)
+  org.scala-lang.modules # scala-parser-combinators_2.11 # 1.0.6 (http://scala-lang.org/)
   org.scala-lang.modules # scala-xml_2.11 # 1.0.3 (http://scala-lang.org/)
   org.scala-lang.modules # scala-xml_2.11 # 1.0.4 (http://scala-lang.org/)
   

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ val commonSettings = Seq(
 val commonTestSettings = Seq(
   libraryDependencies ++= Seq(
     "org.postgresql"   % "postgresql"  % "9.4-1204-jdbc41" % "test",
-    "org.scalikejdbc" %% "scalikejdbc" % "2.3.5" % "test"))
+    "org.scalikejdbc" %% "scalikejdbc" % "3.1.0" % "test"))
 
 val dataElasticsearch1 = (project in file("storage/elasticsearch1")).
   settings(commonSettings: _*).

--- a/storage/jdbc/build.sbt
+++ b/storage/jdbc/build.sbt
@@ -22,7 +22,7 @@ name := "apache-predictionio-data-jdbc"
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
   "org.apache.spark"        %% "spark-sql"      % sparkVersion.value % "provided",
-  "org.scalikejdbc"         %% "scalikejdbc"    % "2.3.5",
+  "org.scalikejdbc"         %% "scalikejdbc"    % "3.1.0",
   "org.postgresql"           % "postgresql"     % "9.4-1204-jdbc41" % "test",
   "org.specs2"              %% "specs2"         % "2.3.13" % "test")
 


### PR DESCRIPTION
Fixes to create a connection object at a worker. Bump scalikejdbc version to 3.1.0 because it's very old.

see [here](https://issues.apache.org/jira/browse/PIO-137)