### PR TITLE
[PIO-179] bump up hbase client version and make it configurable

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1131,7 +1131,7 @@ version.
 --------------------------------------------------------------------------------
 Binary distribution bundles
 
-  junit # junit # 4.11 (http://junit.org/junit4/)
+  junit # junit # 4.12 (http://junit.org/junit4/)
   
   which are available under the CPL v1.0 license (https://eclipse.org/legal/cpl-v10.html)
 
@@ -1353,7 +1353,7 @@ in any resulting litigation.
 --------------------------------------------------------------------------------
 Binary distribution bundles
 
-  org.jamon # jamon-runtime # 2.3.1 (http://www.jamon.org/)
+  org.jamon # jamon-runtime # 2.4.1 (http://www.jamon.org/)
 
   which are available under the MPL v1.1 license (http://www.mozilla.org/MPL/MPL-1.1.txt)
 --------------------------------------------------------------------------------
@@ -1366,6 +1366,9 @@ Binary distribution bundles
   org.slf4j # slf4j-api # 1.7.2 (https://www.slf4j.org/)
   org.slf4j # slf4j-log4j12 # 1.7.18 (https://www.slf4j.org/)
   org.slf4j # slf4j-log4j12 # 1.7.10 (https://www.slf4j.org/)
+  org.jruby.jcodings # jcodings # 1.0.8 (https://github.com/jruby/jcodings/)
+  org.jruby.joni # joni # 2.1.2 (https://github.com/jruby/joni/)
+  
   
   which are available under the MIT license (http://opensource.org/licenses/mit-license.php)
   

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -404,9 +404,6 @@ The GlassFish code released under the CDDL shall be governed by the laws of the 
 --------------------------------------------------------------------------------
 Binary distribution bundles
 
-  com.sun.jersey # jersey-core # 1.8 (https://github.com/jersey/jersey-1.x)
-  com.sun.jersey # jersey-json # 1.8 (https://github.com/jersey/jersey-1.x)
-  com.sun.jersey # jersey-server # 1.8 (https://github.com/jersey/jersey-1.x)
   com.sun.jersey # jersey-core # 1.9 (https://github.com/jersey/jersey-1.x)
   com.sun.jersey # jersey-json # 1.9 (https://github.com/jersey/jersey-1.x)
   com.sun.jersey # jersey-server # 1.9 (https://github.com/jersey/jersey-1.x)
@@ -1782,5 +1779,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 The following libraries are from the public domain.
 
-  com.github.stephenc.high-scale-lib # high-scale-lib # 1.1.1 (https://github.com/stephenc/high-scale-lib)
   org.tukaani # xz # 1.0 (http://tukaani.org/xz/java.html)

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,10 @@ lazy val es = sys.props.getOrElse("elasticsearch.version", "5.5.2")
 
 elasticsearchVersion in ThisBuild := es
 
+lazy val hbase = sys.props.getOrElse("hbase.version", "1.2.6")
+
+hbaseVersion in ThisBuild := hbase
+
 json4sVersion in ThisBuild := scalaSparkDepsVersion(scalaBinaryVersion.value)(sparkBinaryVersion.value)("json4s")
 
 hadoopVersion in ThisBuild := sys.props.getOrElse(

--- a/project/PIOBuild.scala
+++ b/project/PIOBuild.scala
@@ -19,6 +19,7 @@ import sbt._
 
 object PIOBuild {
   val elasticsearchVersion = settingKey[String]("The version of Elasticsearch used for building")
+  val hbaseVersion = settingKey[String]("The version of Hbase used for building")
   val json4sVersion = settingKey[String]("The version of JSON4S used for building")
   val sparkVersion = settingKey[String]("The version of Apache Spark used for building")
   val sparkBinaryVersion = settingKey[String]("The binary version of Apache Spark used for building")

--- a/storage/hbase/build.sbt
+++ b/storage/hbase/build.sbt
@@ -22,11 +22,11 @@ name := "apache-predictionio-data-hbase"
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
   "org.apache.spark"        %% "spark-core"     % sparkVersion.value % "provided",
-  "org.apache.hbase"         % "hbase-common"   % "0.98.5-hadoop2",
-  "org.apache.hbase"         % "hbase-client"   % "0.98.5-hadoop2"
+  "org.apache.hbase"         % "hbase-common"   % hbaseVersion.value,
+  "org.apache.hbase"         % "hbase-client"   % hbaseVersion.value
     exclude("org.apache.zookeeper", "zookeeper"),
   // added for Parallel storage interface
-  "org.apache.hbase"         % "hbase-server"   % "0.98.5-hadoop2"
+  "org.apache.hbase"         % "hbase-server"   % hbaseVersion.value
     exclude("org.apache.hbase", "hbase-client")
     exclude("org.apache.zookeeper", "zookeeper")
     exclude("javax.servlet", "servlet-api")


### PR DESCRIPTION
Since predictionio 0.12+ suggests hbase 1.2.6 by default, it makes sense to also use a the same version of the client instead of the now outdated 0.98.5. 

In the interest of flexibility, this change makes it configurable at build time by passing -Dhbase.version=...