### PR TITLE
fix "$pio eval" command

### DIFF
--- a/docs/manual/source/evaluation/metricbuild.html.md
+++ b/docs/manual/source/evaluation/metricbuild.html.md
@@ -67,7 +67,7 @@ object. We can run the following command to kick start the evaluation.
 ```
 $ pio build
 ...
-$ pio eval org.example.classification.AccuracyEvaluation org.template.classification.EngineParamsList
+$ pio eval org.example.classification.AccuracyEvaluation org.example.classification.EngineParamsList
 ...
 ```
 

--- a/docs/manual/source/evaluation/metricbuild.html.md
+++ b/docs/manual/source/evaluation/metricbuild.html.md
@@ -67,8 +67,7 @@ object. We can run the following command to kick start the evaluation.
 ```
 $ pio build
 ...
-$ pio eval org.template.classification.AccuracyEvaluation \
-    org.template.classification.EngineParamsList
+$ pio eval org.example.classification.AccuracyEvaluation org.template.classification.EngineParamsList
 ...
 ```
 
@@ -140,8 +139,7 @@ separation of concern when we conduct hyperparameter tuning.
 ```
 $ pio build
 ...
-$ pio eval org.template.classification.PrecisionEvaluation \
-    org.template.classification.EngineParamsList
+$ pio eval org.example.classification.PrecisionEvaluation org.example.classification.EngineParamsList
 ...
 [INFO] [CoreWorkflow$] Starting evaluation instance ID: SMhzYbJ9QgKkD0fQzTA7MA
 ...
@@ -183,7 +181,7 @@ Optimal Engine Params:
   }
 }
 Metrics:
-  org.template.classification.Precision: 0.8846153846153846
+  org.example.classification.Precision: 0.8846153846153846
 ```
 
 (See MyClassification/src/main/scala/***PrecisionEvaluation.scala*** for

--- a/docs/manual/source/evaluation/paramtuning.html.md
+++ b/docs/manual/source/evaluation/paramtuning.html.md
@@ -107,7 +107,7 @@ Optimal Engine Params:
   }
 }
 Metrics:
-  org.template.classification.Accuracy: 0.9281045751633987
+  org.example.classification.Accuracy: 0.9281045751633987
 The best variant params can be found in best.json
 [INFO] [CoreWorkflow$] runEvaluation completed
 ```
@@ -362,8 +362,7 @@ from the console.
 ```
 $ pio build
 ...
-$ pio eval org.template.classification.AccuracyEvaluation \
-    org.template.classification.EngineParamsList
+$ pio eval org.example.classification.AccuracyEvaluation org.example.classification.EngineParamsList
 ```
 
 You will see the following output:

--- a/docs/manual/source/evaluation/paramtuning.html.md
+++ b/docs/manual/source/evaluation/paramtuning.html.md
@@ -59,8 +59,7 @@ workflow for the classification template.
 ```
 $ pio build
 ...
-$ pio eval org.template.classification.AccuracyEvaluation \
-    org.template.classification.EngineParamsList
+$ pio eval org.example.classification.AccuracyEvaluation org.example.classification.EngineParamsList
 ```
 
 You will see the following output:


### PR DESCRIPTION
"$pio eval" command parameters are broken: package name in command does not match the package name in Evaluation.scala