### PR TITLE
Fix several minor typos detected by github.com/client9/misspell

### DIFF
--- a/core/src/main/scala/org/apache/predictionio/controller/Engine.scala
+++ b/core/src/main/scala/org/apache/predictionio/controller/Engine.scala
@@ -268,7 +268,7 @@ class Engine[TD, EI, PD, Q, P, A](
 
   /** Extract model for persistent layer.
     *
-    * PredictionIO presist models for future use. It allows custom
+    * PredictionIO persists models for future use. It allows custom
     * implementation for persisting models. You need to implement the
     * [[org.apache.predictionio.controller.PersistentModel]] interface. This method
     * traverses all models in the workflow. If the model is a
@@ -642,7 +642,7 @@ object Engine {
       dataSource.readTrainingBase(sc)
     } catch {
       case e: StorageClientException =>
-        logger.error(s"Error occured reading from data source. (Reason: " +
+        logger.error(s"Error occurred reading from data source. (Reason: " +
           e.getMessage + ") Please see the log for debugging details.", e)
         sys.exit(1)
     }

--- a/core/src/main/scala/org/apache/predictionio/core/AbstractDoer.scala
+++ b/core/src/main/scala/org/apache/predictionio/core/AbstractDoer.scala
@@ -48,7 +48,7 @@ object Doer extends Logging {
 
     // Subclasses only allows two kind of constructors.
     // 1. Constructor with P <: Params.
-    // 2. Emtpy constructor.
+    // 2. Empty constructor.
     // First try (1), if failed, try (2).
     try {
       val constr = cls.getConstructor(params.getClass)

--- a/core/src/main/scala/org/apache/predictionio/core/SelfCleaningDataSource.scala
+++ b/core/src/main/scala/org/apache/predictionio/core/SelfCleaningDataSource.scala
@@ -69,7 +69,7 @@ trait SelfCleaningDataSource {
 
   /** :: DeveloperApi ::
     *
-    * Returns RDD of events happend after duration in event window params.
+    * Returns RDD of events happened after duration in event window params.
     *
     * @return RDD[Event] most recent PEvents.
     */
@@ -87,7 +87,7 @@ trait SelfCleaningDataSource {
 
   /** :: DeveloperApi ::
     *
-    * Returns Iterator of events happend after duration in event window params.
+    * Returns Iterator of events happened after duration in event window params.
     *
     * @return Iterator[Event] most recent LEvents.
     */

--- a/core/src/main/scala/org/apache/predictionio/workflow/FakeWorkflow.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/FakeWorkflow.scala
@@ -72,7 +72,7 @@ private[predictionio] case class FakeEvalResult() extends BaseEvaluatorResult {
   override val noSave: Boolean = true
 }
 
-/** FakeRun allows user to implement custom function under the exact enviroment
+/** FakeRun allows user to implement custom function under the exact environment
   * as other PredictionIO workflow.
   *
   * Useful for developing new features. Only need to extend this trait and

--- a/data/src/test/scala/org/apache/predictionio/data/webhooks/mailchimp/MailChimpConnectorSpec.scala
+++ b/data/src/test/scala/org/apache/predictionio/data/webhooks/mailchimp/MailChimpConnectorSpec.scala
@@ -24,7 +24,7 @@ import org.specs2.mutable._
 
 class MailChimpConnectorSpec extends Specification with ConnectorTestUtil {
 
-  // TOOD: test other events
+  // TODO: test other events
   // TODO: test different optional fields
 
   "MailChimpConnector" should {
@@ -87,7 +87,7 @@ class MailChimpConnectorSpec extends Specification with ConnectorTestUtil {
         "data[merges][EMAIL]" -> "api+unsub@mailchimp.com",
         "data[merges][FNAME]" -> "MailChimp",
         "data[merges][LNAME]" -> "API",
-        "data[merges][INTERESTS]" -> "Group1,Group2", //optional 
+        "data[merges][INTERESTS]" -> "Group1,Group2", //optional
         "data[ip_opt]" -> "10.20.10.30",
         "data[campaign_id]" -> "cb398d21d2"
       )
@@ -120,7 +120,7 @@ class MailChimpConnectorSpec extends Specification with ConnectorTestUtil {
       check(MailChimpConnector, unsubscribe, expected)
     }
 
-    //check profile update to event Json 
+    //check profile update to event Json
     "convert profile update to event JSON" in {
 
       val profileUpdate = Map(
@@ -162,7 +162,7 @@ class MailChimpConnectorSpec extends Specification with ConnectorTestUtil {
       check(MailChimpConnector, profileUpdate, expected)
     }
 
-    //check email update to event Json 
+    //check email update to event Json
     "convert email update to event JSON" in {
 
       val emailUpdate = Map(
@@ -192,7 +192,7 @@ class MailChimpConnectorSpec extends Specification with ConnectorTestUtil {
       check(MailChimpConnector, emailUpdate, expected)
     }
 
-    //check cleaned email to event Json 
+    //check cleaned email to event Json
     "convert cleaned email to event JSON" in {
 
       val cleanedEmail = Map(
@@ -221,7 +221,7 @@ class MailChimpConnectorSpec extends Specification with ConnectorTestUtil {
       check(MailChimpConnector, cleanedEmail, expected)
     }
 
-    //check campaign sending status to event Json 
+    //check campaign sending status to event Json
     "convert campaign sending status to event JSON" in {
 
       val campaign = Map(

--- a/data/test.sh
+++ b/data/test.sh
@@ -481,7 +481,7 @@ testdata='[{
 checkPOST "/batch/events.json?accessKey=$accessKey" "$testdata" 200
 
 # request with a malformed event (2nd event)
-# the response code is succesful but the error for individual event is reflected in the response's body.
+# the response code is successful but the error for individual event is reflected in the response's body.
 testdata='[{
   "event" : "my_event_1",
   "entityType" : "user",

--- a/storage/hbase/src/main/scala/org/apache/predictionio/data/storage/hbase/HBEventsUtil.scala
+++ b/storage/hbase/src/main/scala/org/apache/predictionio/data/storage/hbase/HBEventsUtil.scala
@@ -148,7 +148,7 @@ object HBEventsUtil {
     val rowKey = event.eventId.map { id =>
       RowKey(id) // create rowKey from eventId
     }.getOrElse {
-      // TOOD: use real UUID. not pseudo random
+      // TODO: use real UUID. not pseudo random
       val uuidLow: Long = UUID.randomUUID().getLeastSignificantBits
       RowKey(
         entityType = event.entityType,

--- a/tests/pio_tests/README.md
+++ b/tests/pio_tests/README.md
@@ -33,14 +33,14 @@ has to download the following python-3 packages:
 You can pass it arguments to:
 * suppress the output of executed shell commands within the tests
 * enable logging
-* specify which tests should be exectued (by names)
+* specify which tests should be executed (by names)
 
 For more information run:
 ```shell
 python3 tests.py -h
 ```
 
-As soon as the tests are finishied an XML file with JUnit-like test reports 
+As soon as the tests are finished an XML file with JUnit-like test reports
 is created in the directory of execution.
 
 ### Adding new tests

--- a/tests/pio_tests/utils.py
+++ b/tests/pio_tests/utils.py
@@ -55,7 +55,7 @@ def repository_dirname(template):
 
 def obtain_template(engine_dir, template):
   """Given a directory with engines and a template downloads an engine
-  if neccessary
+  if necessary
   Args:
     engine_dir (str): directory where engines are stored
     template (str): either the name of an engine from the engines directory

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/App.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/App.scala
@@ -298,7 +298,7 @@ object App extends EitherLogging {
               Right(channel.copy(id = chanId))
             } else {
               errStr = s"""Unable to create new channel.
-                          |Failed to initalize Event Store.""".stripMargin
+                          |Failed to initialize Event Store.""".stripMargin
               error(errStr)
               // reverted back the meta data
               try {


### PR DESCRIPTION
This pull request fixes several minor typos in the source code. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

```
$ misspell .
PMC.md:74:64: "depedency" is a misspelling of "dependency"
README.md:57:5: "Similiar" is a misspelling of "Similar"
conf/server.conf:22:20: "Evalutaion" is a misspelling of "Evaluation"
core/src/main/scala/org/apache/predictionio/controller/Engine.scala:271:19: "presist" is a misspelling of "persist"
core/src/main/scala/org/apache/predictionio/controller/Engine.scala:645:29: "occured" is a misspelling of "occurred"
core/src/main/scala/org/apache/predictionio/core/AbstractDoer.scala:51:10: "Emtpy" is a misspelling of "Empty"
core/src/main/scala/org/apache/predictionio/core/SelfCleaningDataSource.scala:72:28: "happend" is a misspelling of "happened"
core/src/main/scala/org/apache/predictionio/core/SelfCleaningDataSource.scala:90:33: "happend" is a misspelling of "happened"
core/src/main/scala/org/apache/predictionio/workflow/FakeWorkflow.scala:75:69: "enviroment" is a misspelling of "environment"
data/src/test/scala/org/apache/predictionio/data/webhooks/mailchimp/MailChimpConnectorSpec.scala:27:5: "TOOD" is a misspelling of "TODO"
data/test.sh:484:23: "succesful" is a misspelling of "successful"
docs/manual/source/demo/tapster.html.md:420:10: "documenation" is a misspelling of "documentation"
docs/manual/source/deploy/index.html.md:97:84: "supress" is a misspelling of "suppress"
docs/manual/source/evaluation/metricbuild.html.md:33:42: "demonstate" is a misspelling of "demonstrate"
docs/manual/source/evaluation/metricbuild.html.md:105:50: "simliar" is a misspelling of "similar"
docs/manual/source/evaluation/metricchoose.html.md:46:7: "classificaiton" is a misspelling of "classification"
docs/manual/source/evaluation/metricchoose.html.md:80:17: "tranform" is a misspelling of "transform"
docs/manual/source/evaluation/paramtuning.html.md:296:25: "accuray" is a misspelling of "accuracy"
docs/manual/source/gallery/templates.yaml:230:26: "occurence" is a misspelling of "occurrence"
docs/manual/source/gallery/templates.yaml:468:94: "capabilites" is a misspelling of "capabilities"
docs/manual/source/partials/_footer.html.slim:5:5: "seperator" is a misspelling of "separator"
docs/manual/source/resources/faq.html.md:148:399: "commmand" is a misspelling of "command"
docs/manual/source/stylesheets/partials/_footer.css.scss:7:3: "seperator" is a misspelling of "separator"
docs/manual/source/stylesheets/partials/_footer.css.scss:8:34: "seperator" is a misspelling of "separator"
docs/manual/source/stylesheets/variables/_colors.css.scss:94:8: "seperator" is a misspelling of "separator"
docs/manual/source/templates/complementarypurchase/dase.html.md.erb:242:172: "transcations" is a misspelling of "transactions"
docs/manual/source/templates/complementarypurchase/dase.html.md.erb:248:821: "transcations" is a misspelling of "transactions"
docs/manual/source/templates/complementarypurchase/dase.html.md.erb:286:110: "transcations" is a misspelling of "transactions"
docs/manual/source/templates/ecommercerecommendation/quickstart.html.md.erb:551:49: "decribed" is a misspelling of "described"
docs/manual/source/templates/ecommercerecommendation/dase.html.md.erb:378:202: "avaiable" is a misspelling of "available"
docs/manual/source/templates/ecommercerecommendation/dase.html.md.erb:378:257: "avaiable" is a misspelling of "available"
docs/manual/source/templates/complementarypurchase/quickstart.html.md.erb:247:234: "recommeded" is a misspelling of "recommended"
docs/manual/source/templates/complementarypurchase/quickstart.html.md.erb:332:296: "mutliple" is a misspelling of "multiple"
docs/manual/source/templates/recommendation/batch-evaluator.html.md:73:126: "correpsonding" is a misspelling of "corresponding"
docs/manual/source/templates/recommendation/evaluation.html.md.erb:154:6: "absense" is a misspelling of "absence"
docs/manual/source/templates/recommendation/quickstart.html.md.erb:45:9: "recomended" is a misspelling of "recommended"
docs/manual/source/templates/similarproduct/multi-events-multi-algos.html.md.erb:28:45: "mutliple" is a misspelling of "multiple"
docs/manual/source/templates/similarproduct/multi-events-multi-algos.html.md.erb:400:236: "defintion" is a misspelling of "definition"
docs/manual/source/templates/leadscoring/dase.html.md.erb:444:46: "probabilty" is a misspelling of "probability"
docs/manual/source/templates/similarproduct/dase.html.md.erb:457:300: "simliar" is a misspelling of "similar"
docs/manual/source/tryit/index.html.slim:23:42: "dependancies" is a misspelling of "dependencies"
docs/manual/source/tryit/index.html.slim:28:63: "dependancies" is a misspelling of "dependencies"
docs/manual/source/tryit/index.html.slim:52:33: "recomended" is a misspelling of "recommended"
storage/hbase/src/main/scala/org/apache/predictionio/data/storage/hbase/HBEventsUtil.scala:151:9: "TOOD" is a misspelling of "TODO"
tests/pio_tests/README.md:36:32: "exectued" is a misspelling of "executed"
tests/pio_tests/utils.py:58:5: "neccessary" is a misspelling of "necessary"
tools/src/main/scala/org/apache/predictionio/tools/commands/App.scala:301:37: "initalize" is a misspelling of "initialize"
```