### PR TITLE
Sync Template Gallery

### DIFF
--- a/docs/manual/source/gallery/templates.yaml
+++ b/docs/manual/source/gallery/templates.yaml
@@ -137,7 +137,7 @@
     language: Scala
     license: "Apache Licence 2.0"
     status: stable
-    pio_min_version: 0.10.0-incubating
+    pio_min_version: 0.11.0-incubating
     apache_pio_convesion_required: "already compatible"
     support_link: '<a href="http://predictionio.apache.org/support/">Apache PredictionIO mailing lists</a>'
 
@@ -158,7 +158,7 @@
     language: Scala
     license: "Apache Licence 2.0"
     status: alpha
-    pio_min_version: 0.10.0-incubating
+    pio_min_version: 0.11.0-incubating
     apache_pio_convesion_required: "already compatible"
     support_link: '<a href="http://predictionio.apache.org/support/">Apache PredictionIO mailing lists</a>'
 
@@ -172,7 +172,7 @@
     language: Scala
     license: "Apache Licence 2.0"
     status: stable
-    pio_min_version: 0.10.0-incubating
+    pio_min_version: 0.11.0-incubating
     apache_pio_convesion_required: "already compatible"
     support_link: '<a href="http://predictionio.apache.org/support/">Apache PredictionIO mailing lists</a>'
 
@@ -193,7 +193,7 @@
     language: Java
     license: "Apache Licence 2.0"
     status: alpha
-    pio_min_version: 0.9.3
+    pio_min_version: 0.11.0-incubating
     apache_pio_convesion_required: "requires conversion"
     support_link: '<a href="http://predictionio.apache.org/support/">Apache PredictionIO mailing lists</a>'
 
@@ -305,7 +305,7 @@
     language: Scala
     license: "Apache Licence 2.0"
     status: stable
-    pio_min_version: 0.9.2
+    pio_min_version: 0.11.0-incubating
     apache_pio_convesion_required: "already compatible"
     support_link: '<a href="http://predictionio.apache.org/support/">Apache PredictionIO mailing lists</a>'
 
@@ -345,7 +345,7 @@
     language: Scala
     license: "Apache Licence 2.0"
     status: alpha
-    pio_min_version: 0.9.2
+    pio_min_version: 0.11.0-incubating
     apache_pio_convesion_required: "requires conversion"
     support_link: '<a href="https://github.com/apache/predictionio-template-text-classifier/issues">Github issues</a>'
 
@@ -695,7 +695,7 @@
     language: Scala
     license: "Apache Licence 2.0"
     status: stable
-    pio_min_version: 0.9.2
+    pio_min_version: 0.11.0-incubating
     apache_pio_convesion_required: "already compatible"
     support_link: '<a href="http://predictionio.apache.org/support/">Apache PredictionIO mailing lists</a>'
 


### PR DESCRIPTION
Since the official templates now use `org.apache.predictionio` package they requires 0.11.0-incubating at least. I updated all `template.json` in the official templates with update for PredictionIO 0.13.0. Also the template gallery should be synchronized with them.