### PR TITLE
[PIO-153] Allow use of GNU tar on non-GNU systems

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -112,7 +112,12 @@ cp -r ${DISTDIR} ${TARDIR}
 cp LICENSE.txt ${TARDIR}
 cp NOTICE.txt ${TARDIR}
 
-tar zcvf ${TARNAME} ${TARDIR}
+# Allows override for `tar` command
+# This enables using GNU tar on systems such as macOS
+if [ -z "$TAR" ] ; then
+  TAR=tar
+fi
+$TAR zcvf ${TARNAME} ${TARDIR}
 rm -rf ${TARDIR}
 
 echo -e "\033[0;32mPredictionIO binary distribution created at $TARNAME\033[0m"


### PR DESCRIPTION
@chanlee514 please review.

@shimamoto you may want to include this in your PMC doc update.

This addresses warnings when tarball is created using non-GNU tar (e.g. macOS). Here's an [example](https://superuser.com/questions/318809/linux-os-x-tar-incompatibility-tarballs-created-on-os-x-give-errors-when-unt).