### PR TITLE
[PIO-167] Remove temporal maintenance tool from community projects

### DIFF
--- a/docs/manual/source/community/projects.html.md
+++ b/docs/manual/source/community/projects.html.md
@@ -41,11 +41,6 @@ and submit a pull request.
  - Minh-Tu Le: https://github.com/minhtule/Tapster-iOS-Demo
 
 
-## Template Maintainer
-
- - Naoki Takezoe: https://github.com/takezoe/predictionio-templates-maintenance
-
-
 ## Universal Recommender
 
  - ActionML: https://github.com/actionml/universal-recommender


### PR DESCRIPTION
Further update following #472.

First of all, Great thanks for @Wei-1's documentation work.

But I don't want to list my maintenance scripts for the official templates in the community page because we need a essntial solution to make the official templates maintenance easy and these scripts are very temporary. I don't want to spread them officially. This pull request is just remove it from the community powered projects page.

I appreciate your understanding and cooperation.