### PR TITLE
[PIO-182] Add async methods to LEventStore

### DIFF
--- a/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
@@ -86,20 +86,18 @@ object LEventStore {
 
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    val (appId, channelId) = Common.appNameToId(appName, channelName)
-
-    Await.result(eventsDb.futureFind(
-      appId = appId,
-      channelId = channelId,
-      startTime = startTime,
-      untilTime = untilTime,
-      entityType = Some(entityType),
-      entityId = Some(entityId),
+    Await.result(findByEntityAsync(
+      appName = appName,
+      entityType = entityType,
+      entityId = entityId,
+      channelName = channelName,
       eventNames = eventNames,
       targetEntityType = targetEntityType,
       targetEntityId = targetEntityId,
+      startTime = startTime,
+      untilTime = untilTime,
       limit = limit,
-      reversed = Some(latest)),
+      latest = latest),
       timeout)
   }
 
@@ -194,18 +192,16 @@ object LEventStore {
 
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    val (appId, channelId) = Common.appNameToId(appName, channelName)
-
-    Await.result(eventsDb.futureFind(
-      appId = appId,
-      channelId = channelId,
-      startTime = startTime,
-      untilTime = untilTime,
+    Await.result(findAsync(
+      appName = appName,
       entityType = entityType,
       entityId = entityId,
+      channelName = channelName,
       eventNames = eventNames,
       targetEntityType = targetEntityType,
       targetEntityId = targetEntityId,
+      startTime = startTime,
+      untilTime = untilTime,
       limit = limit), timeout)
   }
 

--- a/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
@@ -41,6 +41,9 @@ import scala.concurrent.duration.Duration
   *   -Dscala.concurrent.context.numThreads=1000 \
   *   -Dscala.concurrent.context.maxThreads=1000"
   * </pre>
+  *
+  * You can learn more about the global execution context in the Scala documentation:
+  * [[https://docs.scala-lang.org/overviews/core/futures.html#the-global-execution-context]]
   */
 object LEventStore {
 

--- a/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
@@ -84,6 +84,7 @@ object LEventStore {
     latest: Boolean = true,
     timeout: Duration = defaultTimeout): Iterator[Event] = {
 
+    // Import here to ensure ExecutionContext.Implicits.global is used only in this method
     import scala.concurrent.ExecutionContext.Implicits.global
 
     Await.result(findByEntityAsync(
@@ -190,6 +191,7 @@ object LEventStore {
     limit: Option[Int] = None,
     timeout: Duration = defaultTimeout): Iterator[Event] = {
 
+    // Import here to ensure ExecutionContext.Implicits.global is used only in this method
     import scala.concurrent.ExecutionContext.Implicits.global
 
     Await.result(findAsync(

--- a/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
@@ -26,7 +26,21 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 
 /** This object provides a set of operation to access Event Store
-  * without going through Spark's parallelization
+  * without going through Spark's parallelization.
+  *
+  * Note that blocking methods of this object uses
+  * `scala.concurrent.ExecutionContext.Implicits.global` internally.
+  * Since this is a thread pool which has a number of threads equal to available
+  * processors, parallelism is limited up to the number of processors.
+  *
+  * If this limitation become bottleneck of resource usage, you can increase the
+  * number of threads by declaring following VM options before calling "pio deploy":
+  *
+  * <pre>
+  * export JAVA_OPTS="$JAVA_OPTS \
+  *   -Dscala.concurrent.context.numThreads=1000 \
+  *   -Dscala.concurrent.context.maxThreads=1000"
+  * </pre>
   */
 object LEventStore {
 
@@ -36,19 +50,6 @@ object LEventStore {
 
   /** Reads events of the specified entity. May use this in Algorithm's predict()
     * or Serving logic to have fast event store access.
-    *
-    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
-    * internally. Since this is a thread pool which has a number of threads equal to
-    * available processors, parallelism is limited up to the number of processors.
-    *
-    * If this limitation become bottleneck of resource usage, you can increase the
-    * number of threads by declaring following VM options before calling "pio deploy":
-    *
-    * <pre>
-    * export JAVA_OPTS="$JAVA_OPTS \
-    *   -Dscala.concurrent.context.numThreads=1000 \
-    *   -Dscala.concurrent.context.maxThreads=1000"
-    * </pre>
     *
     * @param appName return events of this app
     * @param entityType return events of this entityType
@@ -155,19 +156,6 @@ object LEventStore {
 
   /** Reads events generically. If entityType or entityId is not specified, it
     * results in table scan.
-    *
-    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
-    * internally. Since this is a thread pool which has a number of threads equal to
-    * available processors, parallelism is limited up to the number of processors.
-    *
-    * If this limitation become bottleneck of resource usage, you can increase the
-    * number of threads by declaring following VM options before calling "pio deploy":
-    *
-    * <pre>
-    * export JAVA_OPTS="$JAVA_OPTS \
-    *   -Dscala.concurrent.context.numThreads=1000 \
-    *   -Dscala.concurrent.context.maxThreads=1000"
-    * </pre>
     *
     * @param appName return events of this app
     * @param entityType return events of this entityType

--- a/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/LEventStore.scala
@@ -20,11 +20,9 @@ package org.apache.predictionio.data.store
 
 import org.apache.predictionio.data.storage.Storage
 import org.apache.predictionio.data.storage.Event
-
 import org.joda.time.DateTime
 
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 
 /** This object provides a set of operation to access Event Store
@@ -38,6 +36,19 @@ object LEventStore {
 
   /** Reads events of the specified entity. May use this in Algorithm's predict()
     * or Serving logic to have fast event store access.
+    *
+    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
+    * internally. Since this is a thread pool which has a number of threads equal to
+    * available processors, parallelism is limited up to the number of processors.
+    *
+    * If this limitation become bottleneck of resource usage, you can increase the
+    * number of threads by declaring following VM options before calling "pio deploy":
+    *
+    * <pre>
+    * export JAVA_OPTS="$JAVA_OPTS \
+    *   -Dscala.concurrent.context.numThreads=1000 \
+    *   -Dscala.concurrent.context.maxThreads=1000"
+    * </pre>
     *
     * @param appName return events of this app
     * @param entityType return events of this entityType
@@ -72,6 +83,8 @@ object LEventStore {
     latest: Boolean = true,
     timeout: Duration = defaultTimeout): Iterator[Event] = {
 
+    import scala.concurrent.ExecutionContext.Implicits.global
+
     val (appId, channelId) = Common.appNameToId(appName, channelName)
 
     Await.result(eventsDb.futureFind(
@@ -89,8 +102,72 @@ object LEventStore {
       timeout)
   }
 
+  /** Reads events of the specified entity. May use this in Algorithm's predict()
+    * or Serving logic to have fast event store access.
+    *
+    * @param appName return events of this app
+    * @param entityType return events of this entityType
+    * @param entityId return events of this entityId
+    * @param channelName return events of this channel (default channel if it's None)
+    * @param eventNames return events with any of these event names.
+    * @param targetEntityType return events of this targetEntityType:
+    *   - None means no restriction on targetEntityType
+    *   - Some(None) means no targetEntityType for this event
+    *   - Some(Some(x)) means targetEntityType should match x.
+    * @param targetEntityId return events of this targetEntityId
+    *   - None means no restriction on targetEntityId
+    *   - Some(None) means no targetEntityId for this event
+    *   - Some(Some(x)) means targetEntityId should match x.
+    * @param startTime return events with eventTime >= startTime
+    * @param untilTime return events with eventTime < untilTime
+    * @param limit Limit number of events. Get all events if None or Some(-1)
+    * @param latest Return latest event first (default true)
+    * @return Future[Iterator[Event]]
+    */
+  def findByEntityAsync(
+    appName: String,
+    entityType: String,
+    entityId: String,
+    channelName: Option[String] = None,
+    eventNames: Option[Seq[String]] = None,
+    targetEntityType: Option[Option[String]] = None,
+    targetEntityId: Option[Option[String]] = None,
+    startTime: Option[DateTime] = None,
+    untilTime: Option[DateTime] = None,
+    limit: Option[Int] = None,
+    latest: Boolean = true)(implicit ec: ExecutionContext): Future[Iterator[Event]] = {
+
+    val (appId, channelId) = Common.appNameToId(appName, channelName)
+
+    eventsDb.futureFind(
+      appId = appId,
+      channelId = channelId,
+      startTime = startTime,
+      untilTime = untilTime,
+      entityType = Some(entityType),
+      entityId = Some(entityId),
+      eventNames = eventNames,
+      targetEntityType = targetEntityType,
+      targetEntityId = targetEntityId,
+      limit = limit,
+      reversed = Some(latest))
+  }
+
   /** Reads events generically. If entityType or entityId is not specified, it
     * results in table scan.
+    *
+    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
+    * internally. Since this is a thread pool which has a number of threads equal to
+    * available processors, parallelism is limited up to the number of processors.
+    *
+    * If this limitation become bottleneck of resource usage, you can increase the
+    * number of threads by declaring following VM options before calling "pio deploy":
+    *
+    * <pre>
+    * export JAVA_OPTS="$JAVA_OPTS \
+    *   -Dscala.concurrent.context.numThreads=1000 \
+    *   -Dscala.concurrent.context.maxThreads=1000"
+    * </pre>
     *
     * @param appName return events of this app
     * @param entityType return events of this entityType
@@ -127,6 +204,8 @@ object LEventStore {
     limit: Option[Int] = None,
     timeout: Duration = defaultTimeout): Iterator[Event] = {
 
+    import scala.concurrent.ExecutionContext.Implicits.global
+
     val (appId, channelId) = Common.appNameToId(appName, channelName)
 
     Await.result(eventsDb.futureFind(
@@ -140,6 +219,58 @@ object LEventStore {
       targetEntityType = targetEntityType,
       targetEntityId = targetEntityId,
       limit = limit), timeout)
+  }
+
+  /** Reads events generically. If entityType or entityId is not specified, it
+    * results in table scan.
+    *
+    * @param appName return events of this app
+    * @param entityType return events of this entityType
+    *   - None means no restriction on entityType
+    *   - Some(x) means entityType should match x.
+    * @param entityId return events of this entityId
+    *   - None means no restriction on entityId
+    *   - Some(x) means entityId should match x.
+    * @param channelName return events of this channel (default channel if it's None)
+    * @param eventNames return events with any of these event names.
+    * @param targetEntityType return events of this targetEntityType:
+    *   - None means no restriction on targetEntityType
+    *   - Some(None) means no targetEntityType for this event
+    *   - Some(Some(x)) means targetEntityType should match x.
+    * @param targetEntityId return events of this targetEntityId
+    *   - None means no restriction on targetEntityId
+    *   - Some(None) means no targetEntityId for this event
+    *   - Some(Some(x)) means targetEntityId should match x.
+    * @param startTime return events with eventTime >= startTime
+    * @param untilTime return events with eventTime < untilTime
+    * @param limit Limit number of events. Get all events if None or Some(-1)
+    * @return Future[Iterator[Event]]
+    */
+  def findAsync(
+    appName: String,
+    entityType: Option[String] = None,
+    entityId: Option[String] = None,
+    channelName: Option[String] = None,
+    eventNames: Option[Seq[String]] = None,
+    targetEntityType: Option[Option[String]] = None,
+    targetEntityId: Option[Option[String]] = None,
+    startTime: Option[DateTime] = None,
+    untilTime: Option[DateTime] = None,
+    limit: Option[Int] = None)(implicit ec: ExecutionContext): Future[Iterator[Event]] = {
+
+    val (appId, channelId) = Common.appNameToId(appName, channelName)
+
+    eventsDb.futureFind(
+      appId = appId,
+      channelId = channelId,
+      startTime = startTime,
+      untilTime = untilTime,
+      entityType = entityType,
+      entityId = entityId,
+      eventNames = eventNames,
+      targetEntityType = targetEntityType,
+      targetEntityId = targetEntityId,
+      limit = limit)
   }
 
 }

--- a/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
@@ -33,6 +33,19 @@ object LJavaEventStore {
   /** Reads events of the specified entity. May use this in Algorithm's predict()
     * or Serving logic to have fast event store access.
     *
+    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
+    * internally. Since this is a thread pool which has a number of threads equal to
+    * available processors, parallelism is limited up to the number of processors.
+    *
+    * If this limitation become bottleneck of resource usage, you can increase the
+    * number of threads by declaring following VM options before calling "pio deploy":
+    *
+    * <pre>
+    * export JAVA_OPTS="$JAVA_OPTS \
+    *   -Dscala.concurrent.context.numThreads=1000 \
+    *   -Dscala.concurrent.context.maxThreads=1000"
+    * </pre>
+    *
     * @param appName return events of this app
     * @param entityType return events of this entityType
     * @param entityId return events of this entityId
@@ -88,6 +101,19 @@ object LJavaEventStore {
 
   /** Reads events generically. If entityType or entityId is not specified, it
     * results in table scan.
+    *
+    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
+    * internally. Since this is a thread pool which has a number of threads equal to
+    * available processors, parallelism is limited up to the number of processors.
+    *
+    * If this limitation become bottleneck of resource usage, you can increase the
+    * number of threads by declaring following VM options before calling "pio deploy":
+    *
+    * <pre>
+    * export JAVA_OPTS="$JAVA_OPTS \
+    *   -Dscala.concurrent.context.numThreads=1000 \
+    *   -Dscala.concurrent.context.maxThreads=1000"
+    * </pre>
     *
     * @param appName return events of this app
     * @param entityType return events of this entityType

--- a/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
@@ -44,6 +44,9 @@ import scala.compat.java8.FutureConverters._
   *   -Dscala.concurrent.context.numThreads=1000 \
   *   -Dscala.concurrent.context.maxThreads=1000"
   * </pre>
+  *
+  * You can learn more about the global execution context in the Scala documentation:
+  * [[https://docs.scala-lang.org/overviews/core/futures.html#the-global-execution-context]]
   */
 object LJavaEventStore {
 

--- a/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
@@ -26,25 +26,26 @@ import scala.collection.JavaConversions
 import scala.concurrent.duration.Duration
 
 /** This Java-friendly object provides a set of operation to access Event Store
-  * without going through Spark's parallelization
+  * without going through Spark's parallelization.
+  *
+  * Note that blocking methods of this object uses
+  * `scala.concurrent.ExecutionContext.Implicits.global` internally.
+  * Since this is a thread pool which has a number of threads equal to available
+  * processors, parallelism is limited up to the number of processors.
+  *
+  * If this limitation become bottleneck of resource usage, you can increase the
+  * number of threads by declaring following VM options before calling "pio deploy":
+  *
+  * <pre>
+  * export JAVA_OPTS="$JAVA_OPTS \
+  *   -Dscala.concurrent.context.numThreads=1000 \
+  *   -Dscala.concurrent.context.maxThreads=1000"
+  * </pre>
   */
 object LJavaEventStore {
 
   /** Reads events of the specified entity. May use this in Algorithm's predict()
     * or Serving logic to have fast event store access.
-    *
-    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
-    * internally. Since this is a thread pool which has a number of threads equal to
-    * available processors, parallelism is limited up to the number of processors.
-    *
-    * If this limitation become bottleneck of resource usage, you can increase the
-    * number of threads by declaring following VM options before calling "pio deploy":
-    *
-    * <pre>
-    * export JAVA_OPTS="$JAVA_OPTS \
-    *   -Dscala.concurrent.context.numThreads=1000 \
-    *   -Dscala.concurrent.context.maxThreads=1000"
-    * </pre>
     *
     * @param appName return events of this app
     * @param entityType return events of this entityType
@@ -101,19 +102,6 @@ object LJavaEventStore {
 
   /** Reads events generically. If entityType or entityId is not specified, it
     * results in table scan.
-    *
-    * Note that this method uses `scala.concurrent.ExecutionContext.Implicits.global`
-    * internally. Since this is a thread pool which has a number of threads equal to
-    * available processors, parallelism is limited up to the number of processors.
-    *
-    * If this limitation become bottleneck of resource usage, you can increase the
-    * number of threads by declaring following VM options before calling "pio deploy":
-    *
-    * <pre>
-    * export JAVA_OPTS="$JAVA_OPTS \
-    *   -Dscala.concurrent.context.numThreads=1000 \
-    *   -Dscala.concurrent.context.maxThreads=1000"
-    * </pre>
     *
     * @param appName return events of this app
     * @param entityType return events of this entityType

--- a/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/store/java/LJavaEventStore.scala
@@ -18,12 +18,15 @@
 
 package org.apache.predictionio.data.store.java
 
+import java.util.concurrent.{CompletableFuture, CompletionStage, ExecutorService}
+
 import org.apache.predictionio.data.storage.Event
 import org.apache.predictionio.data.store.LEventStore
 import org.joda.time.DateTime
 
 import scala.collection.JavaConversions
 import scala.concurrent.duration.Duration
+import scala.compat.java8.FutureConverters._
 
 /** This Java-friendly object provides a set of operation to access Event Store
   * without going through Spark's parallelization.
@@ -100,6 +103,61 @@ object LJavaEventStore {
       ).toSeq)
   }
 
+  /** Reads events of the specified entity. May use this in Algorithm's predict()
+    * or Serving logic to have fast event store access.
+    *
+    * @param appName return events of this app
+    * @param entityType return events of this entityType
+    * @param entityId return events of this entityId
+    * @param channelName return events of this channel (default channel if it's None)
+    * @param eventNames return events with any of these event names.
+    * @param targetEntityType return events of this targetEntityType:
+    *   - None means no restriction on targetEntityType
+    *   - Some(None) means no targetEntityType for this event
+    *   - Some(Some(x)) means targetEntityType should match x.
+    * @param targetEntityId return events of this targetEntityId
+    *   - None means no restriction on targetEntityId
+    *   - Some(None) means no targetEntityId for this event
+    *   - Some(Some(x)) means targetEntityId should match x.
+    * @param startTime return events with eventTime >= startTime
+    * @param untilTime return events with eventTime < untilTime
+    * @param limit Limit number of events. Get all events if None or Some(-1)
+    * @param latest Return latest event first
+    * @return CompletableFuture[java.util.List[Event]]
+    */
+  def findByEntityAsync(
+    appName: String,
+    entityType: String,
+    entityId: String,
+    channelName: Option[String],
+    eventNames: Option[java.util.List[String]],
+    targetEntityType: Option[Option[String]],
+    targetEntityId: Option[Option[String]],
+    startTime: Option[DateTime],
+    untilTime: Option[DateTime],
+    limit: Option[Integer],
+    latest: Boolean,
+    executorService: ExecutorService): CompletableFuture[java.util.List[Event]] = {
+
+    val eventNamesSeq = eventNames.map(JavaConversions.asScalaBuffer(_).toSeq)
+    val limitInt = limit.map(_.intValue())
+    implicit val ec = fromExecutorService(executorService)
+
+    LEventStore.findByEntityAsync(
+      appName,
+      entityType,
+      entityId,
+      channelName,
+      eventNamesSeq,
+      targetEntityType,
+      targetEntityId,
+      startTime,
+      untilTime,
+      limitInt,
+      latest
+    ).map { x => JavaConversions.seqAsJavaList(x.toSeq) }.toJava.toCompletableFuture
+  }
+
   /** Reads events generically. If entityType or entityId is not specified, it
     * results in table scan.
     *
@@ -156,4 +214,61 @@ object LJavaEventStore {
         timeout
       ).toSeq)
   }
+
+  /** Reads events generically. If entityType or entityId is not specified, it
+    * results in table scan.
+    *
+    * @param appName return events of this app
+    * @param entityType return events of this entityType
+    *   - None means no restriction on entityType
+    *   - Some(x) means entityType should match x.
+    * @param entityId return events of this entityId
+    *   - None means no restriction on entityId
+    *   - Some(x) means entityId should match x.
+    * @param channelName return events of this channel (default channel if it's None)
+    * @param eventNames return events with any of these event names.
+    * @param targetEntityType return events of this targetEntityType:
+    *   - None means no restriction on targetEntityType
+    *   - Some(None) means no targetEntityType for this event
+    *   - Some(Some(x)) means targetEntityType should match x.
+    * @param targetEntityId return events of this targetEntityId
+    *   - None means no restriction on targetEntityId
+    *   - Some(None) means no targetEntityId for this event
+    *   - Some(Some(x)) means targetEntityId should match x.
+    * @param startTime return events with eventTime >= startTime
+    * @param untilTime return events with eventTime < untilTime
+    * @param limit Limit number of events. Get all events if None or Some(-1)
+    * @return CompletableFuture[java.util.List[Event]]
+    */
+  def findAsync(
+    appName: String,
+    entityType: Option[String],
+    entityId: Option[String],
+    channelName: Option[String],
+    eventNames: Option[java.util.List[String]],
+    targetEntityType: Option[Option[String]],
+    targetEntityId: Option[Option[String]],
+    startTime: Option[DateTime],
+    untilTime: Option[DateTime],
+    limit: Option[Integer],
+    executorService: ExecutorService): CompletableFuture[java.util.List[Event]] = {
+
+    val eventNamesSeq = eventNames.map(JavaConversions.asScalaBuffer(_).toSeq)
+    val limitInt = limit.map(_.intValue())
+    implicit val ec = fromExecutorService(executorService)
+
+    LEventStore.findAsync(
+      appName,
+      entityType,
+      entityId,
+      channelName,
+      eventNamesSeq,
+      targetEntityType,
+      targetEntityId,
+      startTime,
+      untilTime,
+      limitInt
+    ).map { x => JavaConversions.seqAsJavaList(x.toSeq) }.toJava.toCompletableFuture
+  }
+
 }


### PR DESCRIPTION
This pull request contains following updates:

- Add async (non-blocking) methods to `LEventStore` and `LJavaEventStore`
- Add Scaladoc about `scala.concurrent.ExecutionContext.Implicits.global` which is used in blocking methods

See also: https://lists.apache.org/thread.html/f14e4f8f29410e4585b3d8e9f646b88293a605f4716d3c4d60771854@%3Cuser.predictionio.apache.org%3E