### PR TITLE
[PIO-184] livedoc 0.9.2 upgrade typo

### DIFF
--- a/docs/manual/source/resources/upgrade.html.md
+++ b/docs/manual/source/resources/upgrade.html.md
@@ -133,7 +133,7 @@ NOTE: If `org.apache.predictionio.data.storage.Storage` is not used at all (such
 - remove `import org.apache.predictionio.data.storage.Storage` and replace it by `import org.apache.predictionio.data.store.LEventStore`
 - change `appId` to `appName` in the XXXAlgorithmParams class.
 - remove this line of code: `@transient lazy val lEventsDb = Storage.getLEvents()`
-- locate where `LEventStore.findByEntity()` is used, change it to `LEventStore.findByEntity()`:
+- locate where `lEventsDb.findSingleEntity()` is used, change it to `LEventStore.findByEntity()`:
 
     For example, change following code
 


### PR DESCRIPTION
In this section:
https://github.com/apache/predictionio/blob/livedoc/docs/manual/source/resources/upgrade.html.md#2-in-xxxalgorithmscala

Line 136:
locate where `LEventStore.findByEntity()` is used, change it to `LEventStore.findByEntity()`

Should be changed to:
locate where `lEventsDb.findSingleEntity()` is used, change it to `LEventStore.findByEntity()`