### PR TITLE
[PIO-185] develop Gitbox link Update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -277,7 +277,7 @@ pomExtra := {
   </parent>
   <scm>
     <connection>scm:git:github.com/apache/predictionio</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/predictionio.git</developerConnection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/predictionio.git</developerConnection>
     <url>github.com/apache/predictionio</url>
   </scm>
   <developers>

--- a/doap.rdf
+++ b/doap.rdf
@@ -35,8 +35,8 @@
     <category rdf:resource="http://projects.apache.org/category/big-data" />
     <repository>
       <GitRepository>
-        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/predictionio.git"/>
-        <browse rdf:resource="https://git-wip-us.apache.org/repos/asf/predictionio.git"/>
+        <location rdf:resource="https://gitbox.apache.org/repos/asf/predictionio.git"/>
+        <browse rdf:resource="https://gitbox.apache.org/repos/asf/predictionio.git"/>
       </GitRepository>
     </repository>
     <maintainer>


### PR DESCRIPTION
For files, build.sbt & doap.rdf:
Update link from `https://git-wip-us.apache.org/repos/asf/predictionio.git`
to `https://gitbox.apache.org/repos/asf/predictionio.git`