### PR TITLE
[PIO-191] Web Front-page Community Link Update

### DIFF
--- a/docs/manual/source/index.html.md.erb
+++ b/docs/manual/source/index.html.md.erb
@@ -49,9 +49,9 @@ learning infrastructure management.
 | --------------- | ---------------- | ------------------------------------ | ----------------- |
 | [Quick Intro](/start/) | [System Architecture](/system/) | [Demo: Recommending Comics](/demo/tapster/) | [Java](/sdk/java/) |
 | [Installation Guide](/install/) | [Event Server Overview](/datacollection/) | [Text Classification](/demo/textclassification/) | [PHP](/sdk/php/) |
-| [Downloading Template](/start/download/) | [Collecting Data](/datacollection/eventapi/) | [Community Contributed Demo](/demo/community/) | [Python](/sdk/python/) |
+| [Downloading Template](/start/download/) | [Collecting Data](/datacollection/eventapi/) | [Community Contributed Demo](/community/projects.html#demos) | [Python](/sdk/python/) |
 | [Deploying an Engine](/start/deploy/) | [Learning DASE](/customize/) |[Dimensionality Reduction](/machinelearning/dimensionalityreduction/)| [Ruby](/sdk/ruby/) |
-| [Customizing an Engine](/start/customize/) | [Implementing DASE](/customize/dase/) ||[Community Contributed](/sdk/community/) |
+| [Customizing an Engine](/start/customize/) | [Implementing DASE](/customize/dase/) ||[Community Contributed](/community/projects.html#sdks) |
 | [App Integration Overview](/appintegration/) | [Evaluation Overview](/evaluation/) |||
 || [Intellij IDEA Guide](/resources/intellij/) |||
 || [Scala API](/api/current/#package) |||


### PR DESCRIPTION
On https://predictionio.apache.org/
`Community Contributed DEMO` and `Community Contributed SDK` are not updated.