### PR TITLE
Fixes a bug that the parent project is missing from Maven repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,6 @@ val root = (project in file(".")).
   settings(commonSettings: _*).
   enablePlugins(ScalaUnidocPlugin).
   settings(
-    skip in publish := true,
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(dataElasticsearch, dataElasticsearch1),
     unidocProjectFilter in (JavaUnidoc, unidoc) := inAnyProject -- inProjects(dataElasticsearch, dataElasticsearch1),
     scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(


### PR DESCRIPTION
Unable to download the artifact from Maven staging repo.


build.sbt
```
name := "template-scala-parallel-classification"

resolvers += "Apache Repository" at
"https://repository.apache.org/content/repositories/orgapachepredictionio-1026"

organization := "org.apache.predictionio"
scalaVersion := "2.11.12"
libraryDependencies ++= Seq(
  "org.apache.predictionio" %% "apache-predictionio-core" % "0.14.0" % "provided",
  "org.apache.spark"        %% "spark-mllib"              % "2.4.0" % "provided")
```

pio build --verbose
```
[INFO] [Engine$] [warn] ==== Apache Repository: tried
[INFO] [Engine$] [warn]   https://repository.apache.org/content/repositories/orgapachepredictionio-1026/org/apache/predictionio/apache-predictionio-parent_2.11/0.14.0/apache-predictionio-parent_2.11-0.14.0.pom

[INFO] [Engine$] [warn] 	Note: Unresolved dependencies path:
[INFO] [Engine$] [warn] 		org.apache.predictionio:apache-predictionio-core_2.11:0.14.0 (/PredictionIO-0.14.0/examples/scala-parallel-classification/add-algorithm/build.sbt#L24-27)
[INFO] [Engine$] [warn] 		  +- org.apache.predictionio:template-scala-parallel-classification_2.11:0.1.0-SNAPSHOT
[INFO] [Engine$] [error] sbt.librarymanagement.ResolveException: unresolved dependency: org.apache.predictionio#apache-predictionio-core_2.11;0.14.0: not found
```

The parent project is missing from Maven staging repo.